### PR TITLE
fix: revert write permissions for PR

### DIFF
--- a/.github/workflows/reusable-agreements.yaml
+++ b/.github/workflows/reusable-agreements.yaml
@@ -12,7 +12,7 @@ on:
 permissions:
   actions: read
   contents: read
-  pull-requests: write
+  pull-requests: read
   statuses: read
 jobs:
   ContributorLicenseAgreement:


### PR DESCRIPTION
Adding write permissions for PR is resulting in error when workflow is being called from a workflow which doesn't grant needed permissions. 

This change will be re-included once new repository template will be released