### PR TITLE
fix(agreements): mint GitHub App installation token in-job

### DIFF
--- a/.github/workflows/reusable-agreements.yaml
+++ b/.github/workflows/reusable-agreements.yaml
@@ -4,26 +4,53 @@ on:
   workflow_call:
     secrets:
       GH_TOKEN:
-        description: Github token
-        required: true
+        description: "GITHUB_TOKEN of the calling workflow. Optional; defaults to github.token."
+        required: false
       PERSONAL_ACCESS_TOKEN:
-        description: Personal access token
-        required: true
+        description: |
+          Legacy PAT with write access to the remote signatures repository
+          (splunk/cla-agreement). Prefer GH_APP_CLIENT_ID/GH_APP_PRIVATE_KEY
+          which mint a short-lived GitHub App installation token in-job.
+        required: false
+      GH_APP_CLIENT_ID:
+        description: |
+          GitHub App client id. When provided together with GH_APP_PRIVATE_KEY,
+          an installation token scoped to splunk/cla-agreement is generated
+          in-job and used in place of PERSONAL_ACCESS_TOKEN.
+        required: false
+      GH_APP_PRIVATE_KEY:
+        description: "GitHub App private key (PEM)."
+        required: false
+
 permissions:
   actions: read
   contents: read
   pull-requests: write
   statuses: read
+
 jobs:
   ContributorLicenseAgreement:
     runs-on: ubuntu-latest
     steps:
+      # NOTE: the App token MUST be minted in the same job that consumes it.
+      # GitHub Actions strips secret-classified values from `jobs.<id>.outputs`
+      # ("Skip output 'token' since it may contain secret"), so minting it in
+      # a separate job and passing via `needs.*.outputs.token` does not work.
+      - name: Generate GitHub App installation token
+        id: app-token
+        if: ${{ secrets.GH_APP_CLIENT_ID != '' && secrets.GH_APP_PRIVATE_KEY != '' }}
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: splunk
+          repositories: cla-agreement
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby accept the CLA') || github.event_name == 'pull_request_target'
         uses: contributor-assistant/github-action@v2.6.1
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+          PERSONAL_ACCESS_TOKEN: ${{ steps.app-token.outputs.token || secrets.PERSONAL_ACCESS_TOKEN }}
         with:
           path-to-signatures: "signatures/version1/cla.json"
           path-to-document: "https://github.com/splunk/cla-agreement/blob/main/CLA.md" # e.g. a CLA or a DCO document
@@ -39,12 +66,21 @@ jobs:
   CodeOfConduct:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App installation token
+        id: app-token
+        if: ${{ secrets.GH_APP_CLIENT_ID != '' && secrets.GH_APP_PRIVATE_KEY != '' }}
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: splunk
+          repositories: cla-agreement
       - name: "COC Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the Code of Conduct and I hereby accept the Terms') || github.event_name == 'pull_request_target'
         uses: contributor-assistant/github-action@v2.6.1
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+          PERSONAL_ACCESS_TOKEN: ${{ steps.app-token.outputs.token || secrets.PERSONAL_ACCESS_TOKEN }}
         with:
           path-to-signatures: "signatures/version1/coc.json"
           path-to-document: "https://github.com/splunk/cla-agreement/blob/main/CODE_OF_CONDUCT.md" # e.g. a COC or a DCO document

--- a/.github/workflows/reusable-agreements.yaml
+++ b/.github/workflows/reusable-agreements.yaml
@@ -31,6 +31,9 @@ permissions:
 jobs:
   ContributorLicenseAgreement:
     runs-on: ubuntu-latest
+    # `secrets` context is not allowed in step `if:` conditions; bridge via env.
+    env:
+      HAS_APP_CREDS: ${{ (secrets.GH_APP_CLIENT_ID != '' && secrets.GH_APP_PRIVATE_KEY != '') && 'true' || 'false' }}
     steps:
       # NOTE: the App token MUST be minted in the same job that consumes it.
       # GitHub Actions strips secret-classified values from `jobs.<id>.outputs`
@@ -38,7 +41,7 @@ jobs:
       # a separate job and passing via `needs.*.outputs.token` does not work.
       - name: Generate GitHub App installation token
         id: app-token
-        if: ${{ secrets.GH_APP_CLIENT_ID != '' && secrets.GH_APP_PRIVATE_KEY != '' }}
+        if: env.HAS_APP_CREDS == 'true'
         uses: actions/create-github-app-token@v3
         with:
           client-id: ${{ secrets.GH_APP_CLIENT_ID }}
@@ -65,10 +68,12 @@ jobs:
           custom-allsigned-prcomment: "****CLA Assistant Lite bot**** All contributors have signed the CLA  ✍️ ✅"
   CodeOfConduct:
     runs-on: ubuntu-latest
+    env:
+      HAS_APP_CREDS: ${{ (secrets.GH_APP_CLIENT_ID != '' && secrets.GH_APP_PRIVATE_KEY != '') && 'true' || 'false' }}
     steps:
       - name: Generate GitHub App installation token
         id: app-token
-        if: ${{ secrets.GH_APP_CLIENT_ID != '' && secrets.GH_APP_PRIVATE_KEY != '' }}
+        if: env.HAS_APP_CREDS == 'true'
         uses: actions/create-github-app-token@v3
         with:
           client-id: ${{ secrets.GH_APP_CLIENT_ID }}
@@ -76,7 +81,7 @@ jobs:
           owner: splunk
           repositories: cla-agreement
       - name: "COC Assistant"
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the Code of Conduct and I hereby accept the Terms') || github.event_name == 'pull_request_target'
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the Code of Conduct and I hereby accept the Terms')  || github.event_name == 'pull_request_target'
         uses: contributor-assistant/github-action@v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN || github.token }}


### PR DESCRIPTION
## Problem

Add-on repos rolled out from [`splunk/addonfactory-repository-template`](https://github.com/splunk/addonfactory-repository-template/blob/main/enforce/.github/workflows/agreements.yaml) now fail the CLA/COC check on every PR, e.g.:

- https://github.com/splunk/splunk-add-on-for-crowdstrike-fdr/actions/runs/27142130630/job/80109909815?pr=971

with:

```
##[error]Please add a personal access token as an environment variable for writing signatures in a remote repository/organization as mentioned in the README.md file
##[error]Could not retrieve repository contents. Status: unknown
```

### Root cause

The template's caller workflow mints a GitHub App installation token in a separate `generate-token` job and passes it via job outputs to `call-workflow-agreements`:

```yaml
jobs:
  generate-token:
    outputs:
      token: ${{ steps.app-token.outputs.token }}
    steps:
      - uses: actions/create-github-app-token@v3
        ...
  call-workflow-agreements:
    needs: generate-token
    uses: splunk/addonfactory-github-workflows/.github/workflows/reusable-agreements.yaml@v1.4
    secrets:
      PERSONAL_ACCESS_TOKEN: ${{ needs.generate-token.outputs.token }}
```

GitHub Actions auto-classifies the App installation token as a secret and **strips it from job outputs** with the annotation:

> `Skip output 'token' since it may contain secret.`

So `needs.generate-token.outputs.token` resolves to an empty string, `PERSONAL_ACCESS_TOKEN` is empty in the consuming job, and `contributor-assistant/github-action` rejects the call. This calling pattern cannot be made to work — the App token must be minted in the same job that consumes it.

## Change

`reusable-agreements.yaml` now mints the App token **inside each job** when App credentials are supplied:

- Adds two optional secrets: `GH_APP_CLIENT_ID` and `GH_APP_PRIVATE_KEY`.
- If both are set, an installation token scoped to `splunk/cla-agreement` is generated via `actions/create-github-app-token@v3` immediately before invoking `contributor-assistant/github-action@v2.6.1`.
- Falls back to legacy `PERSONAL_ACCESS_TOKEN` when App credentials are not provided (back-compat with existing callers).
- `GH_TOKEN` is now optional and defaults to `github.token`.

Callers using App-token auth can simplify to:

```yaml
jobs:
  call-workflow-agreements:
    uses: splunk/addonfactory-github-workflows/.github/workflows/reusable-agreements.yaml@vX.Y
    permissions:
      actions: read
      contents: read
      pull-requests: write
      statuses: read
    secrets:
      GH_APP_CLIENT_ID:   ${{ secrets.GH_APP_CLIENT_ID }}
      GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
```

No `generate-token` job, no PAT.

## Backwards compatibility

Fully backwards compatible:

| Caller passes                                  | Behavior                                       |
| ---------------------------------------------- | ---------------------------------------------- |
| `PERSONAL_ACCESS_TOKEN` (legacy)               | Used directly, as before.                      |
| `GH_APP_CLIENT_ID` + `GH_APP_PRIVATE_KEY`      | Token minted in-job and used.                  |
| Both                                           | App token wins (preferred).                    |
| Neither                                        | Action will fail with original error (no-op for repos without remote signatures setup). |

`GH_TOKEN` is now optional; existing callers passing it continue to work.

## Test plan

End-to-end test via downstream PR — patches `splunk-add-on-for-crowdstrike-fdr` PR #971 to call this branch's `reusable-agreements.yaml` with the App secrets. Will link the green run here before merge.

Made with [Cursor](https://cursor.com)