### PR TITLE
fix: Allowlist splunk_ta_helper[bot] in CLA/COC checks

### DIFF
--- a/.github/workflows/reusable-agreements.yaml
+++ b/.github/workflows/reusable-agreements.yaml
@@ -58,7 +58,7 @@ jobs:
           path-to-signatures: "signatures/version1/cla.json"
           path-to-document: "https://github.com/splunk/cla-agreement/blob/main/CLA.md" # e.g. a CLA or a DCO document
           branch: "main"
-          allowlist: dependabot[bot],renovate[bot]
+          allowlist: dependabot[bot],renovate[bot],splunk_ta_helper[bot]
           remote-organization-name: splunk
           remote-repository-name: cla-agreement
           custom-pr-sign-comment: "I have read the CLA Document and I hereby accept the CLA"
@@ -90,7 +90,7 @@ jobs:
           path-to-signatures: "signatures/version1/coc.json"
           path-to-document: "https://github.com/splunk/cla-agreement/blob/main/CODE_OF_CONDUCT.md" # e.g. a COC or a DCO document
           branch: "main"
-          allowlist: dependabot[bot],renovate[bot]
+          allowlist: dependabot[bot],renovate[bot],splunk_ta_helper[bot]
           remote-organization-name: splunk
           remote-repository-name: cla-agreement
           custom-pr-sign-comment: "I have read the Code of Conduct and I hereby accept the Terms"


### PR DESCRIPTION
The splunk_ta_helper GitHub App authors release/automation commits but cannot sign the CLA, so the agreements check blocks PRs that contain its commits (e.g. splunk/splunk-add-on-for-microsoft-cloud-services#1516).

Add splunk_ta_helper[bot] to the allowlist in both the ContributorLicenseAgreement and CodeOfConduct jobs, alongside the existing dependabot[bot] and renovate[bot] bot exemptions.